### PR TITLE
remove push check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,8 +4,6 @@
 name: .NET
 
 on:
-  push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 


### PR DESCRIPTION
no one can push to master so there is no reason to waste pipeline time on double check